### PR TITLE
v1.2.2: fix broken hardware video decode (gpu_mem)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Metixel Photoframe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.2]
+
+### Fixed
+
+- **Broken hardware video decode on Raspberry Pi 2/3 due to `gpu_mem=16`** —
+  `scripts/quiet_boot.sh` unconditionally appended `gpu_mem=16` to
+  `/boot/firmware/config.txt`, overriding the correct `gpu_mem=128` set by
+  `setup_trixie_metixel.sh` (last line wins).  With only 16 MB of GPU memory
+  the VideoCore VCHI service failed to initialise, disabling the V4L2 hardware
+  decoder (`h264_v4l2m2m`).  VLC fell back to software decode, which could not
+  keep up with 1080p H.264 on the Pi 2/3's ARM cores — causing choppy video
+  playback.  `quiet_boot.sh` no longer touches `gpu_mem` (the setup script
+  owns it).  Also corrected stale `gpu_mem=16` references in `ARCHITECTURE.md`.
+
 ## [1.2.1]
 
 ### Fixed

--- a/scripts/quiet_boot.sh
+++ b/scripts/quiet_boot.sh
@@ -121,7 +121,9 @@ apply_quiet_boot() {
 
     add_config_line "${BOOT_CONFIG}" "disable_splash=1"
     add_config_line "${BOOT_CONFIG}" "avoid_warnings=2"
-    add_config_line "${BOOT_CONFIG}" "gpu_mem=16"
+    # NOTE: do NOT set gpu_mem here.  The setup script (setup_trixie_metixel.sh)
+    # sets gpu_mem=128 for hardware video decode; forcing gpu_mem=16 here would
+    # override it (last line wins) and break the V4L2 hardware decoder.
 
     # -----------------------------------------------------------------------
     # 2. /boot/firmware/cmdline.txt — the critical piece
@@ -250,7 +252,7 @@ fi' "${RC_LOCAL}"
     echo ""
     echo "=== Quiet Boot v3 Applied ==="
     echo ""
-    echo "  config.txt:   disable_splash=1, avoid_warnings=2, gpu_mem=16"
+    echo "  config.txt:   disable_splash=1, avoid_warnings=2"
     echo "  cmdline.txt:  console=tty3 (kernel output hidden), quiet loglevel=0,"
     echo "                logo.nologo, vt.global_cursor_default=0"
     echo "  systemd:      getty@tty1 masked, ShowStatus=no, journal console off"
@@ -279,7 +281,8 @@ revert_quiet_boot() {
     if [ -f "${BOOT_CONFIG}" ]; then
         remove_config_line "${BOOT_CONFIG}" "disable_splash=1"
         remove_config_line "${BOOT_CONFIG}" "avoid_warnings=2"
-        remove_config_line "${BOOT_CONFIG}" "gpu_mem=16"
+        # gpu_mem is intentionally NOT touched — it is managed by the
+        # setup script (setup_trixie_metixel.sh), not quiet boot.
     else
         echo "  ! ${BOOT_CONFIG} not found — skipping"
     fi
@@ -387,7 +390,7 @@ revert_quiet_boot() {
     echo ""
     echo "=== Factory Defaults Restored ==="
     echo ""
-    echo "  config.txt:   disable_splash, avoid_warnings, gpu_mem removed"
+    echo "  config.txt:   disable_splash, avoid_warnings removed"
     echo "  cmdline.txt:  console=tty1 restored, quiet params stripped,"
     echo "                fsck.repair=yes restored"
     echo "  systemd:      getty unmasks, drop-ins removed"

--- a/src/metixel/__init__.py
+++ b/src/metixel/__init__.py
@@ -7,4 +7,4 @@ Raspberry Pi 2/3/4/5 (Mesa EGL via pi3d + cage/XWayland)
 
 """
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"


### PR DESCRIPTION
## Summary
Fixes broken hardware video decode on Raspberry Pi 2/3.

**Root cause:** \scripts/quiet_boot.sh\ unconditionally appended \gpu_mem=16\ to \/boot/firmware/config.txt\, overriding the correct \gpu_mem=128\ set by \setup_trixie_metixel.sh\ (last line wins). With only 16 MB GPU memory, the VideoCore VCHI service failed to initialise, disabling the V4L2 hardware decoder. VLC fell back to software decode, causing choppy 1080p playback on Pi 2/3.

**Fix:** \quiet_boot.sh\ no longer touches \gpu_mem\ (the setup script owns it). Version bumped to 1.2.2 and CHANGELOG updated.

## Changes
- \scripts/quiet_boot.sh\ — remove \gpu_mem=16\ override
- \src/metixel/__init__.py\ — bump version to 1.2.2
- \docs/CHANGELOG.md\ — add 1.2.2 section