### PR TITLE
Release 1.2.5-beta.2

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -218,12 +218,17 @@ $NewVersion = if ($BumpText -match 'version:\s*(\S+)') {
     ($BumpText -split "`n" | Where-Object { $_.Trim() -ne "" } | Select-Object -First 1).Trim()
 }
 
-# If the requested version already matches the current version, __init__.py
-# is unchanged - there's no bump commit to make.  This is the legitimate
-# case where the version is already present on dev, so we continue (skip the
+# If the requested version already matches the version that is COMMITTED on
+# the current branch, there's no bump commit to make - continue (skip the
 # commit) rather than abort.
-$IniPath = Join-Path $RepoRoot "src\metixel\__init__.py"
-$CurrentVersion = (Select-String -Path $IniPath -Pattern '__version__\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+#
+# IMPORTANT: read the current version from git (the committed __version__),
+# NOT from the working-tree file.  bump_version.py has already written the
+# file to $NewVersion just above, so reading the file here would ALWAYS equal
+# $NewVersion and the commit below would be skipped every time - leaving the
+# bump as an uncommitted change and creating the release branch/PR from stale
+# dev.  git show gives the pre-bump committed value regardless.
+$CurrentVersion = (git show HEAD:src/metixel/__init__.py | Select-String '__version__\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
 $VersionChanged = ($NewVersion -ne $CurrentVersion)
 if (-not $VersionChanged) {
     Write-Host "Version $NewVersion is already current on dev - no bump needed." -ForegroundColor Yellow

--- a/src/metixel/__init__.py
+++ b/src/metixel/__init__.py
@@ -7,4 +7,4 @@ Raspberry Pi 2/3/4/5 (Mesa EGL via pi3d + cage/XWayland)
 
 """
 
-__version__ = "1.2.5-beta.1"
+__version__ = "1.2.5-beta.2"

--- a/systemd/metixel-backend.service
+++ b/systemd/metixel-backend.service
@@ -20,7 +20,16 @@ Environment=METIXEL_DISPLAY_BACKEND=auto
 RuntimeDirectory=metixel
 RuntimeDirectoryMode=0755
 
-ExecStartPre=/bin/mkdir -p /opt/metixel/data/logs /opt/metixel/data/cache /opt/metixel/data/config /opt/metixel/data/media /opt/metixel/data/backups
+# Ensure the persistent data dirs exist and are owned by pi.  A
+# root-created metixel.log (e.g. from a one-off root run during install)
+# would otherwise make this pi-run service crash-loop with
+#   PermissionError: .../data/logs/metixel.log
+# The '+' prefix runs as root so it can chown files that were created by
+# root.  mkdir -p is idempotent; chown fixes the log-dir ownership on every
+# (re)start.  Scoped to data/logs (not -R over all of data) so big media
+# trees aren't walked on each restart.
+ExecStartPre=+/bin/mkdir -p /opt/metixel/data/logs /opt/metixel/data/cache /opt/metixel/data/config /opt/metixel/data/media /opt/metixel/data/backups
+ExecStartPre=+/usr/bin/chown -R pi:pi /opt/metixel/data/logs
 ExecStart=/usr/bin/python3 -m metixel --mode backend --config /opt/metixel/data/config.json
 Restart=always
 RestartSec=5


### PR DESCRIPTION
Release 1.2.5-beta.2

Automated by scripts/release.ps1. Once CI passes, this PR merges into
main and the release tag v1.2.5-beta.2 is created.