### PR TITLE
Add support for cursor-hider service in migration and update scripts

### DIFF
--- a/scripts/migrate_to_atomic.sh
+++ b/scripts/migrate_to_atomic.sh
@@ -271,6 +271,20 @@ for unit in metixel-backend.service metixel-cage.service; do
     fi
 done
 
+# The cursor-hider mode is a newer feature; only install its service if the
+# release actually ships it (older releases lack the mode by design, and a
+# unit that execs --mode cursor-hider on old code would crash-loop forever).
+# Mirrors the guard in setup_trixie_metixel.sh.
+CURSOR_HIDER_PRESENT=false
+if [ -f "${RELEASE_DIR}/systemd/metixel-cursor-hider.service" ] \
+   && grep -q "cursor-hider" "${RELEASE_DIR}/src/metixel/__main__.py"; then
+    cp "${RELEASE_DIR}/systemd/metixel-cursor-hider.service" /etc/systemd/system/
+    CURSOR_HIDER_PRESENT=true
+else
+    echo "  ! Release does not support cursor-hider — skipping its service"
+    rm -f /etc/systemd/system/metixel-cursor-hider.service 2>/dev/null || true
+fi
+
 # metixel-frontend.service was the obsolete pre-cage launcher and is no longer
 # shipped.  Some aging devices may still have a stale copy installed from an
 # early release — stop and remove it so it can't linger or double-launch the
@@ -286,6 +300,9 @@ fi
 systemctl daemon-reload
 # Ensure the services are enabled so they survive reboot.
 systemctl enable metixel-backend.service metixel-cage.service 2>/dev/null || true
+if [ "${CURSOR_HIDER_PRESENT}" = true ]; then
+    systemctl enable metixel-cursor-hider.service 2>/dev/null || true
+fi
 
 # ── Update Samba share path → /data ─────────────────────────────────────────
 # The migration moved media/ from ${INSTALL_ROOT}/media to ${DATA_DIR}/media.
@@ -317,6 +334,12 @@ echo "  live   : ${LIVE_LINK} → $(readlink "${LIVE_LINK}")"
 if [ "${RESTART}" = "yes" ]; then
     echo "Restarting services…"
     systemctl enable metixel-backend metixel-cage 2>/dev/null || true
+    if [ "${CURSOR_HIDER_PRESENT}" = true ]; then
+        # Start the hider BEFORE cage so its trigger socket is bound when
+        # cage_launch.sh runs (Before=metixel-cage.service orders them at boot).
+        systemctl enable metixel-cursor-hider 2>/dev/null || true
+        systemctl start metixel-cursor-hider 2>/dev/null || true
+    fi
     systemctl start metixel-backend 2>/dev/null || true
     systemctl start metixel-cage 2>/dev/null || true
 fi

--- a/scripts/uninstall_metixel.sh
+++ b/scripts/uninstall_metixel.sh
@@ -6,8 +6,10 @@
 #
 # Reverts a Raspberry Pi back to its pre-setup state (before running
 # setup_trixie_metixel.sh). This:
-#   1. Stops & removes the Metixel systemd services (stopped FIRST so nothing
-#      reactivates while we tear down the rest)
+#   1. Stops & removes every Metixel systemd service/unit — including any
+#      enablement links, drop-ins, and lingering processes that keep running
+#      even after the unit files are gone (stopped FIRST so nothing reactivates
+#      while we tear down the rest)
 #   2. Reverts all quiet-boot settings (restores factory boot defaults)
 #   3. Removes the iptables port 80 → 8080 redirect
 #   4. Removes the Samba [metixel-media] share and related smb.conf changes
@@ -58,23 +60,51 @@ echo ""
 # 1. Stop & remove Metixel systemd services (before touching anything else)
 # ============================================================================
 echo "[1/9] Stopping and removing Metixel systemd services..."
+# Stop EVERY known Metixel unit unconditionally.  Stopping must not be gated on
+# `systemctl list-unit-files` finding the unit: after a partial uninstall or an
+# upgrade that removed a unit file, systemd still tracks the loaded unit and a
+# service can keep running in the LOAD=not-found / ACTIVE=running state (this
+# is exactly what happened with metixel-cursor-hider.service).
 for svc in metixel-backend metixel-cage metixel-frontend metixel-cursor-hider metixel-enable-wifi; do
-    if systemctl list-unit-files | grep -q "^${svc}\.service"; then
-        # Disable BEFORE stop: for Restart=always units, stopping alone can
-        # race a queued auto-restart. Disabling first + reset-failed clears
-        # the restart state so the unit stays down.
-        systemctl disable "${svc}.service" 2>/dev/null || true
-        systemctl stop "${svc}.service" 2>/dev/null || true
-        systemctl reset-failed "${svc}.service" 2>/dev/null || true
-        echo "  + Stopped & disabled ${svc}.service"
-    fi
-    if [ -f "/etc/systemd/system/${svc}.service" ]; then
-        rm -f "/etc/systemd/system/${svc}.service"
-        echo "  + Removed /etc/systemd/system/${svc}.service"
-    fi
+    # Disable BEFORE stop: for Restart=always units, stopping alone can race a
+    # queued auto-restart. Disabling first + reset-failed clears the restart
+    # state so the unit stays down.
+    systemctl disable "${svc}.service" 2>/dev/null || true
+    systemctl stop "${svc}.service" 2>/dev/null || true
+    systemctl reset-failed "${svc}.service" 2>/dev/null || true
+    echo "  + Stopped & disabled ${svc}.service"
 done
-# Stop any Metixel Python processes that a service wrapper may not have caught.
-pkill -f "/opt/metixel" 2>/dev/null && echo "  + Killed lingering Metixel processes" || true
+
+# Remove the unit files, their drop-in dirs, and any enablement symlinks.
+# `systemctl disable` only removes *.wants links while the unit file still
+# exists — a unit removed out from under systemd (e.g. by a partial uninstall)
+# leaves broken symlinks pointing at nothing behind.
+rm -f /etc/systemd/system/metixel-*.service
+rm -rf /etc/systemd/system/metixel-*.service.d
+rm -f /etc/systemd/system/*.wants/metixel-*.service
+rm -f /etc/systemd/system/*.requires/metixel-*.service
+find /etc/systemd/system -maxdepth 2 -type l -name 'metixel-*' -delete 2>/dev/null || true
+echo "  + Removed Metixel unit files and enablement links"
+systemctl daemon-reload
+
+# Stop any Metixel Python processes a service wrapper may not have caught.
+# The systemd units exec `python3 -m metixel --mode ...`, whose argv contains
+# NO /opt/metixel path — so the old `pkill -f "/opt/metixel"` missed them.
+# Match the python entrypoints instead (legacy setups exec the full path).
+# None of these patterns can match this script's own `bash ...` process.
+for pat in "python3 -m metixel" "python -m metixel" "python3 /opt/metixel" "python /opt/metixel"; do
+    pkill -f "$pat" 2>/dev/null || true
+done
+# cage launches the frontend under the compositor (via cage_launch.sh) and
+# must go too — exact-name match so unrelated processes are left alone.
+pkill -x cage 2>/dev/null || true
+sleep 2
+# SIGKILL any stragglers that ignored the graceful TERM above.
+for pat in "python3 -m metixel" "python -m metixel" "python3 /opt/metixel" "python /opt/metixel"; do
+    pkill -9 -f "$pat" 2>/dev/null || true
+done
+pkill -9 -x cage 2>/dev/null || true
+echo "  + Killed lingering Metixel processes"
 systemctl daemon-reload
 
 # ============================================================================
@@ -219,9 +249,12 @@ if [ -d "${METIXEL_DIR}" ]; then
 else
     echo "  = ${METIXEL_DIR} not present"
 fi
-# Remove the runtime directory created by setup
-rm -rf /run/metixel
-echo "  + Removed /run/metixel"
+# Remove the runtime directory created by setup (may still hold the
+# cursor-hider socket / IPC sockets after the services above are gone).
+if [ -d /run/metixel ]; then
+    rm -rf /run/metixel
+    echo "  + Removed /run/metixel"
+fi
 
 # ============================================================================
 # Summary
@@ -233,7 +266,7 @@ echo "╚═══════════════════════�
 echo ""
 echo "Reverted:"
 echo "  - Quiet boot settings (factory boot defaults restored)"
-echo "  - Metixel systemd services removed"
+echo "  - Metixel systemd services, enablement links & processes removed"
 echo "  - iptables port 80 → 8080 redirect removed"
 echo "  - Samba [metixel-media] share removed"
 echo "  - Wi-Fi captive-portal (hostapd/dnsmasq) config removed"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -249,6 +249,25 @@ else
     fi
 fi
 
+# ── 6b) PROVISION any NEW systemd service shipped by this release ───────────
+# The Blue/Green swap runs the NEW code, but /etc/systemd/system only receives
+# units at install/migration time.  If a release adds a service (e.g.
+# metixel-cursor-hider in 1.2.5), an upgraded device would never run it without
+# this step.  Runs AFTER the health check so a failure here cannot influence
+# the rollback decision above (the new release is already healthy).
+if [ -f "${RELEASE_DIR}/systemd/metixel-cursor-hider.service" ] \
+   && grep -q "cursor-hider" "${RELEASE_DIR}/src/metixel/__main__.py"; then
+    echo "  Installing new systemd service metixel-cursor-hider.service…"
+    cp "${RELEASE_DIR}/systemd/metixel-cursor-hider.service" /etc/systemd/system/
+    systemctl daemon-reload
+    systemctl enable metixel-cursor-hider.service 2>/dev/null || true
+    systemctl start metixel-cursor-hider.service 2>/dev/null || true
+    # Trigger it now — cage_launch.sh already ran during the step [6/7] restart
+    # (before this service existed), so without an explicit trigger the cursor
+    # would stay visible until the next cage restart or reboot.
+    /usr/bin/env python3 "${RELEASE_DIR}/scripts/trigger_cursor_hider.py" 2>/dev/null || true
+fi
+
 # ── 7) RECORD installed packages for future removal ─────────────────────────
 echo "[7/7] Recording installed package manifest…"
 python3 - "${PACKAGE_STATE}" "${APPS_SYS}" "${APPS_PIP}" <<'PYEOF'

--- a/testing/unit_tests/backend/test_update_manager.py
+++ b/testing/unit_tests/backend/test_update_manager.py
@@ -156,6 +156,12 @@ class TestInstallScript:
         # The systemd units are copied, not sed-mutated (the only sed -i left is
         # the Samba share path rewrite, which is unrelated to systemd).
         assert 'sed -i "s|path = ${INSTALL_ROOT}/media|path = ${DATA_DIR}/media|g"' in content
+        # The cursor-hider service (newer feature) is installed + enabled only
+        # when the release ships it — never against code that lacks the
+        # --mode cursor-hider entrypoint (that would crash-loop forever).
+        assert "metixel-cursor-hider.service" in content
+        assert 'grep -q "cursor-hider" "${RELEASE_DIR}/src/metixel/__main__.py"' in content
+        assert "CURSOR_HIDER_PRESENT" in content
 
     def test_migrate_script_repairs_partial_state(self) -> None:
         """A partial/aborted migration (data/ present but no valid live symlink)
@@ -320,6 +326,22 @@ class TestUpdateScript:
 
         # The rename into releases/ still happens after the commit resolution.
         assert 'mv "${STAGING_DIR}" "${RELEASE_DIR}"' in content
+
+    def test_update_script_provisions_new_systemd_service(self) -> None:
+        """An atomic upgrade must install + start a NEW systemd service shipped
+        by the release (e.g. metixel-cursor-hider in 1.2.5).  Devices installed
+        or migrated before the service existed would otherwise never run it."""
+        content = _UPDATE_SCRIPT.read_text(encoding="utf-8")
+
+        # The hider unit is provisioned from the staged release (guarded: only
+        # when the release actually ships the --mode cursor-hider entrypoint).
+        assert "metixel-cursor-hider.service" in content
+        assert 'grep -q "cursor-hider" "${RELEASE_DIR}/src/metixel/__main__.py"' in content
+        assert "systemctl enable metixel-cursor-hider.service" in content
+        assert "systemctl start metixel-cursor-hider.service" in content
+        # Runs AFTER the health check so provisioning can't affect rollback.
+        assert "New release is healthy" in content
+        assert content.index("metixel-cursor-hider.service") > content.index("healthy")
 
 
 class TestAutoUpdateSchedule:


### PR DESCRIPTION
- Implemented conditional installation of the cursor-hider service in migrate_to_atomic.sh based on its presence in the release.
- Enhanced uninstall_metixel.sh to remove lingering processes and enablement links for all Metixel services, including cursor-hider.
- Updated update.sh to provision the cursor-hider service during upgrades if included in the release.
- Added unit tests to verify the installation and provisioning of the cursor-hider service.

## Description

<!-- Describe the change and why you're making it. Link any related issues. -->

Closes #<!-- issue number -->

## Type of change

<!-- Tick the relevant box(es). -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI / tooling
- [ ] Other

## Target branch

<!-- All PRs target `dev`. `main` is release-only — it is updated solely by the
     release process (`scripts/release.ps1`), never directly. -->

- [ ] Base branch is `dev` (not `main`)

## Code quality (also enforced by CI)

<!-- Optional pre-flight — CI runs these on every PR and is the source of truth.
     Run locally only if you want faster feedback. See `CONTRIBUTING.md`. -->

- [ ] `ruff check src/metixel/` passes
- [ ] `ruff format --check src/metixel/` passes
- [ ] `mypy src/metixel/` passes (no errors)
- [ ] `pytest testing/unit_tests/ -q --no-cov` passes

## Required (not covered by CI)

<!-- CI cannot verify these — the author must confirm them. -->

- [ ] Web UI change? `cd testing/web-tests && npx playwright test` passes against a live frame
- [ ] `docs/CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs updated if user-facing behaviour, URLs, or the API changed

## Notes for reviewers

<!-- Anything the reviewer should know: design decisions, trade-offs, testing performed. -->
